### PR TITLE
Description objects: deavtivating release

### DIFF
--- a/c++/gtpsa/desc.hpp
+++ b/c++/gtpsa/desc.hpp
@@ -10,8 +10,29 @@ extern "C" {
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <iostream>
 
-
+/**
+ * gtpsa description object handling
+ *
+ * Description object contains precomputed coefficients. gtpsa will only
+ * allocate a new object if its signature is different to the already known
+ * ones.
+ *
+ * Furthermore generating (and thus also deleteing) description objects is not
+ * thread safe. It is the user's responsibility that desc objects are created
+ * (and deleted) in a thread safe manner.
+ *
+ * Currently the desc objects will not be deleted. Roughly a hundred objects
+ * can be created.
+ *
+ *
+ * A good overview of gtpsa is given by the original authors at
+ * L. Deniau, C. I. Tomoiagă, "Generalised Truncated Power series algebra
+ * for fast particle accelerator transport maps", MOPJE039
+ * 6th International Particle Accelerator Conference IPAC2015,
+ * Richmond, VA, USA
+ */
 namespace gtpsa::mad {
 
 
@@ -23,7 +44,15 @@ namespace gtpsa::mad {
 	inline const desc_t *  getPtr(void) const { return this->ptr; }
 	friend class desc;
 	inline desc_mgr(const desc_t *p) : ptr(p) { if (!p) { throw std::runtime_error("out of memory"); } }
-	inline ~desc_mgr(void)                    { mad_desc_del(this->ptr); this->ptr=nullptr; }
+	inline ~desc_mgr(void)                    {
+            if(!this->ptr){
+                std::cerr << "gtpsa::desc: would delete underlaying desc_t pointer a second time" << std::endl;
+                return;
+            }
+#warning "gtpsa::desc: not deleting underlying gtpsa desc_t object. see comment in <gtpsa/desc.hpp>"
+        //mad_desc_del(this->ptr);
+        this->ptr=nullptr;
+    }
 
     private:
 	// inline desc_mgr(const desc& o)           = delete;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(c++)
+add_subdirectory(c)

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(test_desc_double_allocate test_desc_double_allocate.c)
+target_link_libraries(test_desc_double_allocate
+        gtpsa
+        lapack
+        blas
+        )
+add_test(desc_double_allocate test_desc_double_allocate)

--- a/tests/c/test_desc_double_allocate.c
+++ b/tests/c/test_desc_double_allocate.c
@@ -1,0 +1,16 @@
+#include <mad_desc.h>
+#include <assert.h>
+
+int main(void)
+{
+	const int nv=6, mo=2;
+
+	const desc_t* d1 = mad_desc_newv (nv,     mo    );
+	const desc_t* d2 = mad_desc_newv (nv,     mo    );
+
+	assert(d1 != d2);
+
+	mad_desc_del(d1);
+	mad_desc_del(d2);
+
+}

--- a/tests/c/test_desc_double_allocate.c
+++ b/tests/c/test_desc_double_allocate.c
@@ -1,5 +1,6 @@
 #include <mad_desc.h>
 #include <assert.h>
+#include <stdio.h>
 
 int main(void)
 {
@@ -8,9 +9,9 @@ int main(void)
 	const desc_t* d1 = mad_desc_newv (nv,     mo    );
 	const desc_t* d2 = mad_desc_newv (nv,     mo    );
 
-	assert(d1 != d2);
-
-	mad_desc_del(d1);
+	/* Get the same descriptor if used */
+	assert(d1 == d2);
+	fprintf(stderr, "d1 = %p, d2 = %p\n", (void *)d1, (void*)d2);
 	mad_desc_del(d2);
 
 }


### PR DESCRIPTION
gtpsa library only creates descriptor objects if its signature varies.

Therefore a call to creating a new object will only create a new one if required. Deleting both ptr's would result in a double release. 
So deleting  is now disabled