### PR TITLE
API changes: consistent description objects, const arguments first

### DIFF
--- a/c++/gtpsa/bridge/bridge.hpp
+++ b/c++/gtpsa/bridge/bridge.hpp
@@ -89,9 +89,9 @@ namespace gtpsa {
 	inline auto name()                   const { return this->m_impl.nam();     }
 	inline auto setName(std::string s)         {        this->m_impl.setnam(s); }
 
-	inline std::pair<idx_t,base_type> cycle(std::vector<ord_t>* m, const idx_t i) const {
+	inline std::pair<idx_t,base_type> cycle(const idx_t i, std::vector<ord_t>* m) const {
 	    base_type v = NAN;
-	    idx_t r = this->m_impl.cycle(m, i, &v);
+	    idx_t r = this->m_impl.cycle(i, m, &v);
 	    return std::pair<idx_t, base_type>(r, v);
 	}
 	inline void clear()  { this->m_impl.clear(); }

--- a/c++/gtpsa/desc.cc
+++ b/c++/gtpsa/desc.cc
@@ -28,7 +28,8 @@ gtpsa::mad::desc_info gtpsa::mad::desc::getInfo() const
 	int np = -1;
 	auto nv =  mad_desc_getnv (this->getPtr(), &mo, &np, &po);
 	std::vector<ord_t> orders(nv + np);
-	this->getNo(orders.size(), orders.data());
+#warning "desc: need to get orders"
+	// this->getNo(orders.size(), orders.data());
 	auto info =  desc_info(nv, mo, np, po, orders);
 
 	return info;

--- a/c++/gtpsa/desc.hpp
+++ b/c++/gtpsa/desc.hpp
@@ -105,13 +105,13 @@ namespace gtpsa::mad {
 	inline desc(int nv,         ord_t mo                                  )
 	    : dm( std::make_unique<desc_mgr>( mad_desc_newv  (nv,     mo    ) ) )
 	    {}
-	inline desc(int nv, int np, ord_t mo,                    ord_t po = 0 )
+	inline desc(int nv, ord_t mo, int np, ord_t po = 0 )
 	    : dm( std::make_unique<desc_mgr>( mad_desc_newvp (nv, np, mo, po) ) )
 	    {}
-	inline desc(int nv, int np, const ord_t no[/*nv+np?*/],  ord_t po = 0 )
-	    : dm( std::make_unique<desc_mgr>( mad_desc_newvpo(nv, np, no, po) ) )
+	inline desc(int nv, ord_t mo, int np, ord_t po, const ord_t no[/*nv+np?*/] )
+	    : dm( std::make_unique<desc_mgr>( mad_desc_newvpo(nv, mo, np, po, no) ) )
 	    {}
-	inline desc(int nv, int np, const std::vector<ord_t> no, ord_t po = 0 )
+	inline desc(int nv, ord_t mo, int np, ord_t po, const std::vector<ord_t> no)
 	    : dm( nullptr )
 	    {
 		auto req_elem = nv+np;
@@ -120,7 +120,7 @@ namespace gtpsa::mad {
 		    strm << "nv= "<<nv<<"+ np="<<np <<"="<<req_elem<<"req. elem, got only "<<no.size()<<"elem";
 		    std::runtime_error(strm.str());
 		}
-		this->dm = std::make_unique<desc_mgr> (mad_desc_newvpo(nv, np, no.data(), po));
+		this->dm = std::make_unique<desc_mgr> (mad_desc_newvpo(nv, mo, np, po, no.data()));
 	    }
 	// inline desc(const desc_t* a_desc)                             { this->t_desc = a_desc;                            }
 	// inline desc(const desc&& o) : dm(std::move(o.dm))     {}
@@ -135,9 +135,9 @@ namespace gtpsa::mad {
     public:
 
 	inline int   getNv(ord_t *mo_=0, int *np_=0, ord_t *po_=0) const { return mad_desc_getnv (this->getPtr(), mo_, np_, po_); }
-	inline ord_t getNo(int nn, ord_t *no_)                     const { return mad_desc_getno (this->getPtr(), nn, no_);       }
-	inline ord_t maxOrd(void)                                  const { return mad_desc_maxord(this->getPtr());                }
-	inline ssz_t maxLen(void)                                  const { return mad_desc_maxlen(this->getPtr());                }
+	// inline ord_t getNo(int nn, ord_t *no_)                     const { return mad_desc_getno (this->getPtr(), nn, no_);       }
+	inline ord_t maxOrd(int nn=0, ord_t *no=nullptr)           const { return mad_desc_maxord(this->getPtr(), nn, nullptr);                }
+	inline ssz_t maxLen(ord_t mo)                              const { return mad_desc_maxlen(this->getPtr(), mo);                }
 	inline ssz_t ordLen(const ord_t mo)                        const { return mad_desc_ordlen(this->getPtr(), mo);            }
 	inline ssz_t trunc(const ord_t to)                         const { return mad_desc_gtrunc(this->getPtr(), to);            }
 
@@ -194,7 +194,7 @@ namespace gtpsa::mad {
 	inline idx_t nxtbyord  (std::vector<ord_t> m )          const { return mad_desc_nxtbyord  (this->getPtr(), m.size(), m.data() );  }
 	// inline idx_t nxtbyord  (ssz_t n,       ord_t *m )    const { return mad_desc_nxtbyord  (this->getPtr(), n, m );  }
 
-	inline ord_t mono      (std::vector<ord_t>* m, idx_t i) const { return mad_desc_mono      (this->getPtr(), m->size(), m->data(), i); }
+	inline ord_t mono      (const idx_t i, std::vector<ord_t>* m) const { return mad_desc_mono      (this->getPtr(), i, m->size(), m->data()); }
 
 
 	inline std::string repr(void)                           const { return this->info_s();	}

--- a/c++/gtpsa/intern/with_operators.hpp
+++ b/c++/gtpsa/intern/with_operators.hpp
@@ -133,7 +133,7 @@ namespace gtpsa {
 	    int i = -1;
 	    while(true){
 		std::vector<ord_t> t_orders(n_max);
-		const auto r = this->cycle(&t_orders, i);
+		const auto r = this->cycle(i, &t_orders);
 		i = r.first;
 		if(i == -1){
 		    break;

--- a/c++/gtpsa/mad/wrapper.tpp
+++ b/c++/gtpsa/mad/wrapper.tpp
@@ -193,8 +193,8 @@ namespace gtpsa::mad {
         /**
          * @brief indexing / monomials (return idx_t = -1 if invalid)
          */
-        inline auto mono(std::vector<ord_t> &m, const idx_t i) const {
-            return GTPSA_METH(mono)(this->getPtr(), m.size(), m.data(), i);
+        inline auto mono( const idx_t i, std::vector<ord_t> *m) const {
+            return GTPSA_METH(mono)(this->getPtr(), i, m->size(), m->data());
         }
 
         /**
@@ -215,8 +215,8 @@ namespace gtpsa::mad {
         }
 
 	// can't define order m as const ...
-        inline auto cycle(std::vector<ord_t>* m, const idx_t i, GTPSA_BASE_T *v) const  {
-	    return  GTPSA_METH(cycle)(this->getPtr(), m->size(), m->data(), i, v);
+        inline auto cycle(const idx_t i, std::vector<ord_t>* m, GTPSA_BASE_T *v) const  {
+	    return  GTPSA_METH(cycle)(this->getPtr(), i, m->size(), m->data(), v);
         }
 
         /**

--- a/examples/c++/gtpsa_ex3.cc
+++ b/examples/c++/gtpsa_ex3.cc
@@ -5,7 +5,9 @@
 int main(int argc, char *argv[])
 {
     std::vector<ord_t> m{3,3,2,2,1,1};
-    auto a_desc = std::make_shared<gtpsa::desc>(6, 0, m, 0);
+    const int nv = 6, np=0;
+    const ord_t mo=0, po=0;
+    auto a_desc = std::make_shared<gtpsa::desc>(6, mo, np, po, m);
     std::cout << "desc " << a_desc << std::endl;
 
     auto t1 = gtpsa::tpsa(a_desc, gtpsa::init::default_);

--- a/examples/c++/gtpsa_ex4.cc
+++ b/examples/c++/gtpsa_ex4.cc
@@ -6,13 +6,19 @@ int main(int argc, char *argv[])
 {
     // descriptor for TPSA with 6 variables of order 10,10,10,10,10,10 without parameters
     {
+        const int nv = 6, np = 0;
+        ord_t mo = 0, po = 0;
 	std::vector<ord_t> m{10,10,10,10,10,10};
-	auto d10 = std::make_shared<gtpsa::desc>(6, 0, m, 0);
-	std::cout << "d10 length=" << d10->maxLen() << " coeffs" << std::endl;
+	auto d10 = std::make_shared<gtpsa::desc>(nv, mo, np, po, m);
+	std::cout << "d10 length=" << d10->maxLen(gtpsa::mad::default_) << " coeffs" << std::endl;
     }
+
+    const int nv = 6, np = 0;
+    ord_t mo = 0, po = 0;
     std::vector<ord_t> m{2,2,2,2,1,10};
-    auto d = std::make_shared<gtpsa::desc>(6, 0, m, 0);
-    std::cout << "d   length=" << d->maxLen() << " coeffs" << std::endl;
+
+    auto d = std::make_shared<gtpsa::desc>(6, mo, np, po, m);
+    std::cout << "d   length=" << d->maxLen(gtpsa::mad::default_) << " coeffs" << std::endl;
 
     auto t1 = gtpsa::tpsa(d,  gtpsa::init::default_);
     auto t2 = gtpsa::tpsa(t1, gtpsa::init::same);

--- a/examples/c++/gtpsa_ex5.cc
+++ b/examples/c++/gtpsa_ex5.cc
@@ -7,14 +7,14 @@ int main(int argc, char *argv[])
     {
 	// descriptor for TPSA with 100 variables of order 2 without parameters
 	auto d2 = std::make_shared<gtpsa::desc>(100, 2);
-	std::cout << "d2 length=" << d2->maxLen() << " coeffs" << std::endl;
+	std::cout << "d2 length=" << d2->maxLen(gtpsa::mad::default_) << " coeffs" << std::endl;
     }
 
     // descriptor for TPSA with 6  variables  of order 2 and
     //                          94 parameters of order 1
 
     auto d = std::make_shared<gtpsa::desc>(6, 94, 2, 1);
-    std::cout << "d   length=" << d->maxLen() << " coeffs" << std::endl;
+    std::cout << "d   length=" << d->maxLen(gtpsa::mad::default_) << " coeffs" << std::endl;
 
     auto t1 = gtpsa::tpsa(d,  gtpsa::init::default_);
     auto t2 = gtpsa::tpsa(t1, gtpsa::init::same);

--- a/examples/c++/gtpsa_ex6.cc
+++ b/examples/c++/gtpsa_ex6.cc
@@ -7,7 +7,7 @@ int main(int argc, char *argv[])
 {
 
     auto d = std::make_shared<gtpsa::desc>(6, 4);
-    std::cout << "d   length=" << d->maxLen() << " coeffs" << std::endl;
+    std::cout << "d   length=" << d->maxLen(gtpsa::mad::default_) << " coeffs" << std::endl;
 
     auto t1 = gtpsa::tpsa(d,  gtpsa::init::default_);
 

--- a/python/src/desc.cc
+++ b/python/src/desc.cc
@@ -47,9 +47,9 @@ Args:\n\
 	.def("index"          , py::overload_cast<const std::vector<ord_t>&>( &gtpsa::mad::desc::idx,     py::const_ ))
 	.def(py::init<int, ord_t>(),             desc_newv_doc,
 	     py::arg("nv"), py::arg("mo") = 0)
-	.def(py::init<int, int, ord_t, ord_t>(), desc_newvp_doc,
-	     py::arg("nv"), py::arg("np") = 0, py::arg("mo") = 0, py::arg("po") = 0)
-	.def(py::init<int, int, std::vector<ord_t>, ord_t>(), desc_newvpo_doc,
-	     py::arg("nv"), py::arg("np") = 0, py::arg("mo") = 0, py::arg("po") = 0);
+	.def(py::init<int, ord_t, int, ord_t>(), desc_newvp_doc,
+	     py::arg("nv"), py::arg("mo"), py::arg("np"),  py::arg("po") = 0)
+	.def(py::init<int, ord_t, int, ord_t, std::vector<ord_t>>(), desc_newvpo_doc,
+         py::arg("nv"), py::arg("mo"), py::arg("np"), py::arg("po"), py::arg("ord_vec"));
 
 }


### PR DESCRIPTION
Description object: API change catchup with mad-ng gtpsa's

Methods changed:
    desc creation: nv, mo, np, po ... order always that way
    cycle : index before return arguments
    mono  : index before return arguments