### PR TITLE
[UX] give maximum number of variables if a variable can not be accessed

### DIFF
--- a/python/src/desc.cc
+++ b/python/src/desc.cc
@@ -45,6 +45,11 @@ Args:\n\
 	.def("indexsm"        , &gtpsa::mad::desc::idxsm     )
 	.def("isvalid"        , py::overload_cast<const std::vector<ord_t>&>( &gtpsa::mad::desc::isvalid, py::const_ ))
 	.def("index"          , py::overload_cast<const std::vector<ord_t>&>( &gtpsa::mad::desc::idx,     py::const_ ))
+	.def("info",           [](const gtpsa::mad::desc& inst){
+	                           inst.info(stdout);
+	                        },
+	    "print description info using c' stdout"
+	    )
 	.def(py::init<int, ord_t>(),             desc_newv_doc,
 	     py::arg("nv"), py::arg("mo") = 0)
 	.def(py::init<int, ord_t, int, ord_t>(), desc_newvp_doc,

--- a/python/src/gtpsa_delegator.h
+++ b/python/src/gtpsa_delegator.h
@@ -79,10 +79,17 @@ namespace gtpsa::python {
 	    {
 		size_t n = this->getVectorPtr()->size();
 		if (index < 0){
-		    throw std::out_of_range("index < 0");
+		    std::stringstream strm;
+		    strm << "gtpsa::ss_vect_elem_access (index = " << index
+			 << ") < 0";
+		    throw std::out_of_range(strm.str());
 		}
 		if (index >= n){
-		    throw std::out_of_range("index >= n");
+		    std::stringstream strm;
+		    strm << "gtpsa::ss_vect_elem_access (index=" << index
+			 << ") >= (n=" << this->getVectorPtr()->size()
+			 << ")";
+		    throw std::out_of_range(strm.str());
 		}
 	    }
 

--- a/python/tests/test_ss_vect.py
+++ b/python/tests/test_ss_vect.py
@@ -517,6 +517,26 @@ def test120_attribute_access():
     print(dir(ps))
 
 
+def test_user_indices():
+    named_index_d = dict(x=0, px=1, y=2, py=3, delta=4, ct=5, K=6, dx=7, dy=8)
+    named_index = gtpsa.IndexMapping(named_index_d)
+    desc = gtpsa.desc(6, 2, 3, 2)
+    print(desc)
+    desc.info()
+
+    ps = gtpsa.ss_vect_tpsa(desc, 2, 6, named_index)
+    ps.set_identity()
+
+    with pytest.raises(IndexError):
+        # This is a knob not a variable ... thus no direct access as
+        # subvector
+        # test included as it did cost me some time to realise why
+        # the error
+        ps.dx
+
+    for a_tpsa in [ps.x, ps.px]:
+        pass
+
 ## if __name__ == "__main__":
 ##     test70_sst_hessian()
 ##

--- a/src/c++/gtpsa/desc.cc
+++ b/src/c++/gtpsa/desc.cc
@@ -1,12 +1,16 @@
 #include <gtpsa/desc.hpp>
+#include <cassert>
+#include <iostream>
+
 void gtpsa::mad::desc_info::show(std::ostream& strm) const
 {
-	strm << " number of variables: "           << this->getNumberOfVariables()
-	     << " maximum order for variables: "   << int(this->getVariablesMaximumOrder())
-	     << " number of parameters: "          << this->getNumberOfParameters()
-	     << " maximum order for parameters: "  << int(this->getParametersMaximumOrder());
+	strm << "description object"
+	     << "\n\t number of variables:          "           << this->getNumberOfVariables()
+	     << "\n\t maximum order for variables:  "   << int(this->getVariablesMaximumOrder())
+	     << "\n\t number of parameters:         "          << this->getNumberOfParameters()
+	     << "\n\t maximum order for parameters: "  << int(this->getParametersMaximumOrder());
 
-	strm  << " orders [";
+	strm  << "\n\t orders [";
 
 	bool first = true;
 	for(auto&o: this->getOrderPerParameter()){
@@ -22,17 +26,20 @@ void gtpsa::mad::desc_info::show(std::ostream& strm) const
 	strm << "]";
 }
 
+// need to upgrade to c++20
+#define ensure(arg) assert(arg)
+
 gtpsa::mad::desc_info gtpsa::mad::desc::getInfo() const
 {
-	ord_t mo=-1, po=-1;
+	ord_t mo=-1, po=-1, max_order=-1;
 	int np = -1;
 	auto nv =  mad_desc_getnv (this->getPtr(), &mo, &np, &po);
-	std::vector<ord_t> orders(nv + np);
-#warning "desc: need to get orders"
-	// this->getNo(orders.size(), orders.data());
-	auto info =  desc_info(nv, mo, np, po, orders);
 
-	return info;
+	std::vector<ord_t> orders(nv + np);
+	max_order = mad_desc_maxord(this->getPtr(), orders.size(), orders.data());
+	ensure(max_order>=0 && max_order!=-1);
+
+	return desc_info(nv, mo, np, po, orders);
 }
 
 void gtpsa::mad::desc::show(std::ostream& o) const

--- a/src/c++/gtpsa/desc.hpp
+++ b/src/c++/gtpsa/desc.hpp
@@ -74,21 +74,21 @@ namespace gtpsa::mad {
      */
     class desc_info {
 	const int m_nv, m_np;
-	const ord_t m_no, m_po;
+	const ord_t m_mo, m_po;
 	const std::vector<ord_t> m_orders;
 
     public:
-	inline desc_info(int nv, ord_t no, int np, ord_t po, const std::vector<ord_t> orders)
+	inline desc_info(int nv, ord_t mo, int np, ord_t po, const std::vector<ord_t> orders)
 	    : m_nv(nv)
 	    , m_np(np)
-	    , m_no(no)
+	    , m_mo(mo)
 	    , m_po(po)
 	    , m_orders(orders)
 	    {}
 
 	inline auto getNumberOfVariables      ( void ) const { return this->m_nv; }
 	inline auto getNumberOfParameters     ( void ) const { return this->m_np; }
-	inline auto getVariablesMaximumOrder  ( void ) const { return this->m_no; }
+	inline auto getVariablesMaximumOrder  ( void ) const { return this->m_mo; }
 	inline auto getParametersMaximumOrder ( void ) const { return this->m_po; }
 
 	/**
@@ -113,7 +113,7 @@ namespace gtpsa::mad {
 	inline desc(int nv, ord_t mo, int np, ord_t po = 0 )
 	    : dm( std::make_unique<desc_mgr>( mad_desc_newvp (nv, mo, np, po) ) )
 	    {}
-	inline desc(int nv, ord_t mo, int np, ord_t po, const ord_t no[/*nv+np?*/] )
+	inline desc(int nv, ord_t mo, int np, ord_t po, const ord_t no[/*nv+np?*/])
 	    : dm( std::make_unique<desc_mgr>( mad_desc_newvpo(nv, mo, np, po, no) ) )
 	    {}
 	inline desc(int nv, ord_t mo, int np, ord_t po, const std::vector<ord_t> no)

--- a/tests/c++/test_desc.cc
+++ b/tests/c++/test_desc.cc
@@ -2,8 +2,10 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
+#include <boost/test/tools/output_test_stream.hpp>
 #include <gtpsa/desc.hpp>
 #include <iostream>
+#include <cassert>
 
 // Simple check for some methods
 
@@ -123,32 +125,47 @@ BOOST_AUTO_TEST_CASE(test20_tpsa_isvaildsm)
 
 BOOST_AUTO_TEST_CASE(test31_desc_info)
 {
-    const int nv = 3, no =7;
-    auto a_desc = gtpsa::desc(nv, no);
+    const int nv = 3, mo =7;
+    auto a_desc = gtpsa::desc(nv, mo);
     a_desc.info();
     auto info = a_desc.getInfo();
-    std::cout << " info " << info  << std::endl;
+    {
+	boost::test_tools::output_test_stream output;
+	output << info;
+    }
 
     BOOST_CHECK_EQUAL(nv, info.getNumberOfVariables());
-    BOOST_CHECK_EQUAL(no, info.getVariablesMaximumOrder());
+    BOOST_CHECK_EQUAL(mo, info.getVariablesMaximumOrder());
     BOOST_CHECK_EQUAL(0 , info.getNumberOfParameters());
     BOOST_CHECK_EQUAL(0 , info.getParametersMaximumOrder());
+
+    auto m_order = info.getOrderPerParameter();
+    assert(m_order.at(0) == mo);
+    BOOST_CHECK_EQUAL(m_order.at(0), mo);
+    BOOST_CHECK_EQUAL(m_order.at(nv-1), mo);
 }
+
 
 
 BOOST_AUTO_TEST_CASE(test33_desc_info)
 {
     // currently fails for 144 on my machine
-    const int nv = 3, no =7, np=62, po=1;
-    auto a_desc = gtpsa::desc(nv, no, np, po);
+    const int nv = 3, mo =7, np=13, po=1;
+    auto a_desc = gtpsa::desc(nv, mo, np, po);
     a_desc.info();
     auto info = a_desc.getInfo();
-    std::cout << " info: " << info << std::endl;
+    std::cout << "info: " << info << std::endl;
+
+    auto m_order = info.getOrderPerParameter();
 
     BOOST_CHECK_EQUAL(nv, info.getNumberOfVariables());
-    BOOST_CHECK_EQUAL(no, info.getVariablesMaximumOrder());
+    BOOST_CHECK_EQUAL(mo, info.getVariablesMaximumOrder());
     BOOST_CHECK_EQUAL(np, info.getNumberOfParameters());
     BOOST_CHECK_EQUAL(po, info.getParametersMaximumOrder());
+
+    BOOST_CHECK_EQUAL(m_order.at(nv-1), mo);
+    BOOST_CHECK_EQUAL(m_order.at(np-1), po);
+
 }
 
 BOOST_AUTO_TEST_CASE(test30_desc_nv)
@@ -159,12 +176,12 @@ BOOST_AUTO_TEST_CASE(test30_desc_nv)
     // BOOST_CHECK_EQUAL(a_desc.getNv(), nv);
 }
 
-
-BOOST_AUTO_TEST_CASE(test31_desc_for_bba)
-{
-    const int nv = 7, np = 144 * 3;
-    const ord_t mo = 3, po = 1;
-    auto a_desc = gtpsa::desc(nv, mo, np, po);
-
-    // BOOST_CHECK_EQUAL(a_desc.getNv(), nv);
-}
+// what would be possible ?
+// BOOST_AUTO_TEST_CASE(test31_desc_for_bba)
+// {
+//     const int nv = 7, np = 144 * 3;
+//     const ord_t mo = 3, po = 1;
+//     auto a_desc = gtpsa::desc(nv, mo, np, po);
+//
+//     // BOOST_CHECK_EQUAL(a_desc.getNv(), nv);
+// }


### PR DESCRIPTION
State space vector only consists of variables.
Names are used for variables and for knobs.

Knobs have indices which are higher than variables. 
One can still us the name as attribute of the state space vector, but that will fail.

The error message has been improved as far as possible in a straightforward manner