### PR TITLE
TpsaOrDouble not leaked to python

### DIFF
--- a/python/src/gtpsa_variant.cc
+++ b/python/src/gtpsa_variant.cc
@@ -12,120 +12,10 @@
 #include <gtpsa/gtpsa_base_variant.hpp>
 #include <gtpsa/tpsa_double_variant.hpp>
 #include <gtpsa/ctpsa_complex_variant.hpp>
-#include <variant>
+#include <gtpsa/python/utils.h>
 
-namespace py=pybind11;
+namespace py = pybind11;
 namespace gpy = gtpsa::python;
-
-// helper type for std::visit
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-// explicit deduction guide (not needed as of C++20)
-template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
-
-// inspired by https://stackoverflow.com/a/52393977
-// this struct is not meant to be instantiated, but to statically provide ::type
-template <typename T, typename... Args> struct variant_prepender;
-
-// Create a variant type from another variant type by prepending its list of
-// alternative types with std::monostate
-// this struct is not meant to be instantiated, but to statically provide ::type
-template <typename Variant> struct monostated : public variant_prepender<Variant, std::monostate>
-{};
-
-
-template <typename... Args0, typename... Args1>
-struct variant_prepender<std::variant<Args0...>, Args1...> {
-    using type = std::variant<Args1..., Args0...>;
-};
-
-
-
-// Implementation of variant_cast_no_monostate()
-// inspired by https://stackoverflow.com/a/47204507
-template <class... Args>
-struct variant_cast_no_monostate_impl
-{
-    std::variant<Args...> v;
-
-    template <class... ToArgs>
-    operator std::variant<ToArgs...>() const
-    {
-        return std::visit(overloaded {
-		[](const std::monostate&) -> std::variant<ToArgs...>
-		{
-		    throw std::runtime_error("variant_cast_no_monostate received a value of type std::monostate, cannot cast it");
-		    return 0.0;
-		},
-		[](double&& arg) -> std::variant<ToArgs...>
-		{
-		    return arg ;
-		},
-		[](gtpsa::tpsa&& arg) -> std::variant<ToArgs...>
-		{
-		    return arg ;
-		},
-	    }, v);
-    }
-};
-
-// Will convert one variant value into a value of another variant type that
-// needs not to have a std::monostate in his alternative types. So the value
-// converted must not be of type std::monostate else an exception is thrown.
-template <class... Args>
-auto variant_cast_no_monostate(const std::variant<Args...>& v) -> variant_cast_no_monostate_impl<Args...>
-{
-    return {v};
-}
-
-
-template<class Cls>
-struct AddMethods {
-    template<typename T>
-    void add_methods(py::class_<Cls> a_cls) {
-    }
-};
-
-template<typename C, typename T>
-static auto to_tpsa_base_variant(const typename C::variant_type tmp)
-{
-    T res = std::visit(overloaded {
-	    [](const typename C::base_type& arg) { return T(arg); },
-	    [](const typename C::tpsa_type& arg) { return T(arg); }
-	}, tmp);
-    return res;
-}
-
-
-template<class C>
-class PythonVisitor : public gtpsa::GTpsaOrBaseVisitorImplementation<C>
-{
-    py::object m_obj;
-
-public:
-    virtual void visit(const gtpsa::GTpsaOrBase<C>& o) override final {
-	py::object obj;
-
-	auto arg = this->getArg(o);
-	std::visit(overloaded {
-		[&obj](const typename C::base_type& arg) { obj = py::cast(arg); },
-		[&obj](const typename C::tpsa_type& arg) { obj = py::cast(arg); }
-	}, arg);
-	m_obj = obj;
-    }
-
-    auto getObject(void) const {
-	return this->m_obj;
-    }
-
-};
-
-template<typename C, typename T>
-auto to_pyobject(T& inst)
-{
-    PythonVisitor<C> visitor;
-    inst.accept(visitor);
-    return visitor.getObject();
-}
 
 static const char to_object_doc[] = "return the stored variant as a python object.";
 template<typename Types, typename Class>
@@ -133,7 +23,7 @@ void add_methods(py::class_<Class> t_mapper)
 {
     t_mapper
 	.def("__repr__", &Class::pstr)
-	.def("to_object", [](Class& inst){ return to_pyobject<Types, Class>(inst); }, to_object_doc)
+	.def("to_object", [](Class& inst){ return gpy::intern::to_pyobject<Types, Class>(inst); }, to_object_doc)
 	.def(py::self += py::self)
 	.def(py::self -= py::self)
 	.def(py::self *= py::self)
@@ -160,7 +50,7 @@ void add_methods(py::class_<Class> t_mapper)
 	.def(py::init<>(
 		 /* is this used at all ? */
 		 [](typename Types::variant_type& v) {
-		     return to_tpsa_base_variant<Types, Class>(v);
+		     return gpy::intern::to_tpsa_base_variant<Types, Class>(v);
 		 }),
 	     "initialise tpsa or double", py::arg("tpsa or double"))
 	;

--- a/src/c++/CMakeLists.txt
+++ b/src/c++/CMakeLists.txt
@@ -32,6 +32,7 @@ set(gtpsa_c++_intern_HEADERS
 set(gtpsa_c++_python_HEADERS
   gtpsa/python/name_index.h
   gtpsa/python/objects_with_named_index.h
+  gtpsa/python/utils.h
   )
 
 set(gtpsa_c++_HEADERS

--- a/src/c++/gtpsa/gtpsa_base_variant.hpp
+++ b/src/c++/gtpsa/gtpsa_base_variant.hpp
@@ -96,7 +96,7 @@ namespace gtpsa {
 	    return strm.str();
 	}
 
-	virtual  void accept(GTpsaOrBaseVisitor<C>& visitor) {
+	virtual  void accept(GTpsaOrBaseVisitor<C>& visitor) const {
 	    visitor.visit(*this);
 	}
 

--- a/src/c++/gtpsa/python/utils.h
+++ b/src/c++/gtpsa/python/utils.h
@@ -11,129 +11,65 @@ namespace gtpsa::python {
     namespace intern {
 
 // helper type for std::visit
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+	template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 // explicit deduction guide (not needed as of C++20)
-template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
-
-#if 0
-// inspired by https://stackoverflow.com/a/52393977
-// this struct is not meant to be instantiated, but to statically provide ::type
-template <typename T, typename... Args> struct variant_prepender;
-
-// Create a variant type from another variant type by prepending its list of
-// alternative types with std::monostate
-// this struct is not meant to be instantiated, but to statically provide ::type
-template <typename Variant> struct monostated : public variant_prepender<Variant, std::monostate>
-{};
+	template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 
-template <typename... Args0, typename... Args1>
-struct variant_prepender<std::variant<Args0...>, Args1...> {
-    using type = std::variant<Args1..., Args0...>;
-};
+        template<typename C, typename T>
+            static auto to_tpsa_base_variant(const typename C::variant_type tmp)
+        {
+            T res = std::visit(overloaded {
+                    [](const typename C::base_type& arg) { return T(arg); },
+                    [](const typename C::tpsa_type& arg) { return T(arg); }
+                }, tmp);
+            return res;
+        }
 
 
+        template<class C>
+            class PythonVisitor : public gtpsa::GTpsaOrBaseVisitorImplementation<C>
+        {
+            pybind11::object m_obj;
 
-// Implementation of variant_cast_no_monostate()
-// inspired by https://stackoverflow.com/a/47204507
-template <class... Args>
-struct variant_cast_no_monostate_impl
-{
-    std::variant<Args...> v;
+        public:
+            virtual void visit(const gtpsa::GTpsaOrBase<C>& o) override final {
+                pybind11::object obj;
 
-    template <class... ToArgs>
-    operator std::variant<ToArgs...>() const
-    {
-        return std::visit(overloaded {
-		[](const std::monostate&) -> std::variant<ToArgs...>
-		{
-		    throw std::runtime_error("variant_cast_no_monostate received a value of type std::monostate, cannot cast it");
-		    return 0.0;
-		},
-		[](double&& arg) -> std::variant<ToArgs...>
-		{
-		    return arg ;
-		},
-		[](gtpsa::tpsa&& arg) -> std::variant<ToArgs...>
-		{
-		    return arg ;
-		},
-	    }, v);
-    }
-};
+                auto arg = this->getArg(o);
+                std::visit(overloaded {
+                        [&obj](const typename C::base_type& arg) { obj = pybind11::cast(arg); },
+                        [&obj](const typename C::tpsa_type& arg) { obj = pybind11::cast(arg); }
+                    }, arg);
+                m_obj = obj;
+            }
 
-// Will convert one variant value into a value of another variant type that
-// needs not to have a std::monostate in his alternative types. So the value
-// converted must not be of type std::monostate else an exception is thrown.
-template <class... Args>
-auto variant_cast_no_monostate(const std::variant<Args...>& v) -> variant_cast_no_monostate_impl<Args...>
-{
-    return {v};
-}
+            inline auto getObject(void) const {
+                return this->m_obj;
+            }
 
+        };
 
-template<class Cls>
-struct AddMethods {
-    template<typename T>
-    void add_methods(pybind11::class_<Cls> a_cls) {
-    }
-};
-
-#endif
-
-template<typename C, typename T>
-static auto to_tpsa_base_variant(const typename C::variant_type tmp)
-{
-    T res = std::visit(overloaded {
-	    [](const typename C::base_type& arg) { return T(arg); },
-	    [](const typename C::tpsa_type& arg) { return T(arg); }
-	}, tmp);
-    return res;
-}
-
-
-template<class C>
-class PythonVisitor : public gtpsa::GTpsaOrBaseVisitorImplementation<C>
-{
-    pybind11::object m_obj;
-
-public:
-    virtual void visit(const gtpsa::GTpsaOrBase<C>& o) override final {
-	pybind11::object obj;
-
-	auto arg = this->getArg(o);
-	std::visit(overloaded {
-		[&obj](const typename C::base_type& arg) { obj = pybind11::cast(arg); },
-		[&obj](const typename C::tpsa_type& arg) { obj = pybind11::cast(arg); }
-	}, arg);
-	m_obj = obj;
-    }
-
-    inline auto getObject(void) const {
-	return this->m_obj;
-    }
-
-};
-
-template<typename C, typename T>
-static auto to_pyobject(const T& inst)
-{
-    PythonVisitor<C> visitor;
-    inst.accept(visitor);
-    return visitor.getObject();
-}
+        template<typename C, typename T>
+            static auto to_pyobject(const T& inst)
+        {
+            PythonVisitor<C> visitor;
+            inst.accept(visitor);
+            return visitor.getObject();
+        }
 
     } //  namespace gtpsa::python::intern
 
-// support conversion to python object within c++ wrapper
-template<typename T>
-static auto to_pyobject(const T& arg) { return pybind11::cast(arg); }
-static auto to_pyobject(const gtpsa::TpsaOrDouble&   arg){
-    return gtpsa::python::intern::to_pyobject<gtpsa::TpsaVariantDoubleTypes, gtpsa::TpsaOrDouble>(arg);
-}
-static auto to_pyobject(const gtpsa::CTpsaOrComplex& arg) {
-    return gtpsa::python::intern::to_pyobject<gtpsa::TpsaVariantComplexTypes, gtpsa::CTpsaOrComplex>(arg);
-}
+    // support conversion to python object within c++ wrapper
+    // i.e. do not leak C++ variant type
+    template<typename T>
+        static auto to_pyobject(const T& arg) { return pybind11::cast(arg); }
+    static auto to_pyobject(const gtpsa::TpsaOrDouble&   arg){
+        return gtpsa::python::intern::to_pyobject<gtpsa::TpsaVariantDoubleTypes, gtpsa::TpsaOrDouble>(arg);
+    }
+    static auto to_pyobject(const gtpsa::CTpsaOrComplex& arg) {
+        return gtpsa::python::intern::to_pyobject<gtpsa::TpsaVariantComplexTypes, gtpsa::CTpsaOrComplex>(arg);
+    }
 
 
 } // namespace gtpsa::python

--- a/src/c++/gtpsa/python/utils.h
+++ b/src/c++/gtpsa/python/utils.h
@@ -1,0 +1,141 @@
+#ifndef _GTPSA_PYTHON_UTILS_H_
+#define _GTPSA_PYTHON_UTILS_H_ 1
+
+#include <pybind11/pybind11.h>
+#include <gtpsa/gtpsa_base_variant.hpp>
+#include <gtpsa/tpsa_double_variant.hpp>
+#include <gtpsa/ctpsa_complex_variant.hpp>
+
+namespace gtpsa::python {
+
+    namespace intern {
+
+// helper type for std::visit
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+// explicit deduction guide (not needed as of C++20)
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+#if 0
+// inspired by https://stackoverflow.com/a/52393977
+// this struct is not meant to be instantiated, but to statically provide ::type
+template <typename T, typename... Args> struct variant_prepender;
+
+// Create a variant type from another variant type by prepending its list of
+// alternative types with std::monostate
+// this struct is not meant to be instantiated, but to statically provide ::type
+template <typename Variant> struct monostated : public variant_prepender<Variant, std::monostate>
+{};
+
+
+template <typename... Args0, typename... Args1>
+struct variant_prepender<std::variant<Args0...>, Args1...> {
+    using type = std::variant<Args1..., Args0...>;
+};
+
+
+
+// Implementation of variant_cast_no_monostate()
+// inspired by https://stackoverflow.com/a/47204507
+template <class... Args>
+struct variant_cast_no_monostate_impl
+{
+    std::variant<Args...> v;
+
+    template <class... ToArgs>
+    operator std::variant<ToArgs...>() const
+    {
+        return std::visit(overloaded {
+		[](const std::monostate&) -> std::variant<ToArgs...>
+		{
+		    throw std::runtime_error("variant_cast_no_monostate received a value of type std::monostate, cannot cast it");
+		    return 0.0;
+		},
+		[](double&& arg) -> std::variant<ToArgs...>
+		{
+		    return arg ;
+		},
+		[](gtpsa::tpsa&& arg) -> std::variant<ToArgs...>
+		{
+		    return arg ;
+		},
+	    }, v);
+    }
+};
+
+// Will convert one variant value into a value of another variant type that
+// needs not to have a std::monostate in his alternative types. So the value
+// converted must not be of type std::monostate else an exception is thrown.
+template <class... Args>
+auto variant_cast_no_monostate(const std::variant<Args...>& v) -> variant_cast_no_monostate_impl<Args...>
+{
+    return {v};
+}
+
+
+template<class Cls>
+struct AddMethods {
+    template<typename T>
+    void add_methods(pybind11::class_<Cls> a_cls) {
+    }
+};
+
+#endif
+
+template<typename C, typename T>
+static auto to_tpsa_base_variant(const typename C::variant_type tmp)
+{
+    T res = std::visit(overloaded {
+	    [](const typename C::base_type& arg) { return T(arg); },
+	    [](const typename C::tpsa_type& arg) { return T(arg); }
+	}, tmp);
+    return res;
+}
+
+
+template<class C>
+class PythonVisitor : public gtpsa::GTpsaOrBaseVisitorImplementation<C>
+{
+    pybind11::object m_obj;
+
+public:
+    virtual void visit(const gtpsa::GTpsaOrBase<C>& o) override final {
+	pybind11::object obj;
+
+	auto arg = this->getArg(o);
+	std::visit(overloaded {
+		[&obj](const typename C::base_type& arg) { obj = pybind11::cast(arg); },
+		[&obj](const typename C::tpsa_type& arg) { obj = pybind11::cast(arg); }
+	}, arg);
+	m_obj = obj;
+    }
+
+    inline auto getObject(void) const {
+	return this->m_obj;
+    }
+
+};
+
+template<typename C, typename T>
+static auto to_pyobject(const T& inst)
+{
+    PythonVisitor<C> visitor;
+    inst.accept(visitor);
+    return visitor.getObject();
+}
+
+    } //  namespace gtpsa::python::intern
+
+// support conversion to python object within c++ wrapper
+template<typename T>
+static auto to_pyobject(const T& arg) { return pybind11::cast(arg); }
+static auto to_pyobject(const gtpsa::TpsaOrDouble&   arg){
+    return gtpsa::python::intern::to_pyobject<gtpsa::TpsaVariantDoubleTypes, gtpsa::TpsaOrDouble>(arg);
+}
+static auto to_pyobject(const gtpsa::CTpsaOrComplex& arg) {
+    return gtpsa::python::intern::to_pyobject<gtpsa::TpsaVariantComplexTypes, gtpsa::CTpsaOrComplex>(arg);
+}
+
+
+} // namespace gtpsa::python
+
+#endif /* _GTPSA_PYTHON_UTILS_H_ */


### PR DESCRIPTION
Knobs in C++ are represented as TpsaOrDouble or CTpsaOrDouble. So the user can use a a constant or tpsa object.
These are settable by the python objects of gtpsa.tpsa or double (or the corresponding types of complex).

When returned (e.g. get_dx) now the internal representation is converted to the appropriate python object.

