### PR TITLE
[TASK] checking large number of parameters

### DIFF
--- a/src/c++/gtpsa/gtpsa_base_variant.hpp
+++ b/src/c++/gtpsa/gtpsa_base_variant.hpp
@@ -117,10 +117,10 @@ namespace gtpsa {
         inline GTpsaOrBase  operator*  (const base_type    b) const { GTpsaOrBase n = *this; mul_helper(this->m_arg, b, &n.m_arg); return n; }
         inline GTpsaOrBase  operator/  (const base_type    b) const { GTpsaOrBase n = *this; div_helper(this->m_arg, b, &n.m_arg); return n; }
 
-        inline GTpsaOrBase  operator+  (const tpsa_type    b) const { GTpsaOrBase n = *this; add_helper(this->m_arg, b, &n.m_arg); return n; }
-        inline GTpsaOrBase  operator-  (const tpsa_type    b) const { GTpsaOrBase n = *this; sub_helper(this->m_arg, b, &n.m_arg); return n; }
-        inline GTpsaOrBase  operator*  (const tpsa_type    b) const { GTpsaOrBase n = *this; mul_helper(this->m_arg, b, &n.m_arg); return n; }
-        inline GTpsaOrBase  operator/  (const tpsa_type    b) const { GTpsaOrBase n = *this; div_helper(this->m_arg, b, &n.m_arg); return n; }
+        inline GTpsaOrBase  operator+  (const tpsa_type&   b) const { GTpsaOrBase n = *this; add_helper(this->m_arg, b, &n.m_arg); return n; }
+        inline GTpsaOrBase  operator-  (const tpsa_type&   b) const { GTpsaOrBase n = *this; sub_helper(this->m_arg, b, &n.m_arg); return n; }
+        inline GTpsaOrBase  operator*  (const tpsa_type&   b) const { GTpsaOrBase n = *this; mul_helper(this->m_arg, b, &n.m_arg); return n; }
+        inline GTpsaOrBase  operator/  (const tpsa_type&   b) const { GTpsaOrBase n = *this; div_helper(this->m_arg, b, &n.m_arg); return n; }
 
         inline GTpsaOrBase  operator+  (const GTpsaOrBase& b) const { GTpsaOrBase n = *this; add_helper(this->m_arg, b.m_arg, &n.m_arg); return n; }
         inline GTpsaOrBase  operator-  (const GTpsaOrBase& b) const { GTpsaOrBase n = *this; sub_helper(this->m_arg, b.m_arg, &n.m_arg); return n; }
@@ -132,10 +132,10 @@ namespace gtpsa {
         inline GTpsaOrBase  dmul       (const base_type    a) const { GTpsaOrBase n = *this; mul_helper(a, this->m_arg, &n.m_arg); return n; }
         inline GTpsaOrBase  ddiv       (const base_type    a) const { GTpsaOrBase n = *this; div_helper(a, this->m_arg, &n.m_arg); return n; }
 
-        inline GTpsaOrBase  dadd       (const tpsa_type    a) const { GTpsaOrBase n = *this; add_helper(a, this->m_arg, &n.m_arg); return n; }
-        inline GTpsaOrBase  dsub       (const tpsa_type    a) const { GTpsaOrBase n = *this; sub_helper(a, this->m_arg, &n.m_arg); return n; }
-        inline GTpsaOrBase  dmul       (const tpsa_type    a) const { GTpsaOrBase n = *this; mul_helper(a, this->m_arg, &n.m_arg); return n; }
-        inline GTpsaOrBase  ddiv       (const tpsa_type    a) const { GTpsaOrBase n = *this; div_helper(a, this->m_arg, &n.m_arg); return n; }
+        inline GTpsaOrBase  dadd       (const tpsa_type&   a) const { GTpsaOrBase n = *this; add_helper(a, this->m_arg, &n.m_arg); return n; }
+        inline GTpsaOrBase  dsub       (const tpsa_type&   a) const { GTpsaOrBase n = *this; sub_helper(a, this->m_arg, &n.m_arg); return n; }
+        inline GTpsaOrBase  dmul       (const tpsa_type&   a) const { GTpsaOrBase n = *this; mul_helper(a, this->m_arg, &n.m_arg); return n; }
+        inline GTpsaOrBase  ddiv       (const tpsa_type&   a) const { GTpsaOrBase n = *this; div_helper(a, this->m_arg, &n.m_arg); return n; }
 
         /**
          *
@@ -181,22 +181,22 @@ namespace gtpsa {
 
 
     template<class C>
-    inline GTpsaOrBase<C> operator+ (const typename C::base_type a, const GTpsaOrBase<C>& b){ return b.dadd(a); }
+    inline GTpsaOrBase<C> operator+ (const typename C::base_type  a, const GTpsaOrBase<C>& b){ return b.dadd(a); }
     template<class C>
-    inline GTpsaOrBase<C> operator- (const typename C::base_type a, const GTpsaOrBase<C>& b){ return b.dsub(a); }
+    inline GTpsaOrBase<C> operator- (const typename C::base_type  a, const GTpsaOrBase<C>& b){ return b.dsub(a); }
     template<class C>
-    inline GTpsaOrBase<C> operator* (const typename C::base_type a, const GTpsaOrBase<C>& b){ return b.dmul(a); }
+    inline GTpsaOrBase<C> operator* (const typename C::base_type  a, const GTpsaOrBase<C>& b){ return b.dmul(a); }
     template<class C>
-    inline GTpsaOrBase<C> operator/ (const typename C::base_type a, const GTpsaOrBase<C>& b){ return b.ddiv(a); }
+    inline GTpsaOrBase<C> operator/ (const typename C::base_type  a, const GTpsaOrBase<C>& b){ return b.ddiv(a); }
 
     template<class C>
-    inline GTpsaOrBase<C> operator+ (const typename C::tpsa_type a, const GTpsaOrBase<C>& b){ return b.dadd(a); }
+    inline GTpsaOrBase<C> operator+ (const typename C::tpsa_type& a, const GTpsaOrBase<C>& b){ return b.dadd(a); }
     template<class C>
-    inline GTpsaOrBase<C> operator- (const typename C::tpsa_type a, const GTpsaOrBase<C>& b){ return b.dsub(a); }
+    inline GTpsaOrBase<C> operator- (const typename C::tpsa_type& a, const GTpsaOrBase<C>& b){ return b.dsub(a); }
     template<class C>
-    inline GTpsaOrBase<C> operator* (const typename C::tpsa_type a, const GTpsaOrBase<C>& b){ return b.dmul(a); }
+    inline GTpsaOrBase<C> operator* (const typename C::tpsa_type& a, const GTpsaOrBase<C>& b){ return b.dmul(a); }
     template<class C>
-    inline GTpsaOrBase<C> operator/ (const typename C::tpsa_type a, const GTpsaOrBase<C>& b){ return b.ddiv(a); }
+    inline GTpsaOrBase<C> operator/ (const typename C::tpsa_type& a, const GTpsaOrBase<C>& b){ return b.ddiv(a); }
 
     /*
     template<class C>

--- a/src/c++/gtpsa/intern/with_operators.cpp
+++ b/src/c++/gtpsa/intern/with_operators.cpp
@@ -1,0 +1,1 @@
+#include <gtpsa/intern/with_operators.hpp>

--- a/src/c++/gtpsa/intern/with_operators.hpp
+++ b/src/c++/gtpsa/intern/with_operators.hpp
@@ -13,9 +13,9 @@ namespace gtpsa {
     class TpsaWithOp : public TpsaBridge<T>
     {
     public:
-	using bridge = TpsaBridge<T>;
-	using base_type = typename T::base_type;
-
+        using bridge = TpsaBridge<T>;
+        using base_type = typename T::base_type;
+        typedef std::tuple<std::vector<ord_t>, base_type, idx_t> coeff_t ;
     public:
         inline TpsaWithOp(std::shared_ptr<mad::desc> desc, const ord_t mo)
             : bridge(desc, mo)
@@ -70,90 +70,98 @@ namespace gtpsa {
          * operators: use already defined functions
          */
         inline TpsaWithOp& operator += (const TpsaWithOp& o ) { this->add(*this, o); return *this; }
-	// (a_i-b_i)/max(|a_i|,1)
-	inline TpsaWithOp& operator -= (const TpsaWithOp& o ) { this->sub(*this, o); return *this; }
-	inline TpsaWithOp& operator *= (const TpsaWithOp& o ) { this->mul(*this, o); return *this; }
-	inline TpsaWithOp& operator /= (const TpsaWithOp& o ) { this->div(*this, o); return *this; }
+        // (a_i-b_i)/max(|a_i|,1)
+        inline TpsaWithOp& operator -= (const TpsaWithOp& o ) { this->sub(*this, o); return *this; }
+        inline TpsaWithOp& operator *= (const TpsaWithOp& o ) { this->mul(*this, o); return *this; }
+        inline TpsaWithOp& operator /= (const TpsaWithOp& o ) { this->div(*this, o); return *this; }
 
-	/*
-	 * operators with base type as one argument
-	 */
-	inline TpsaWithOp& operator += (const typename T::base_type& o ){ this->set(   1e0,    o); return *this; }
-	inline TpsaWithOp& operator -= (const typename T::base_type& o ){ this->set(   1e0,   -o); return *this; }
-	inline TpsaWithOp& operator *= (const typename T::base_type& o ){ this->set(     o,  0e0); return *this; }
-	inline TpsaWithOp& operator /= (const typename T::base_type& o ){ this->set( 1e0/o,  0e0); return *this; }
+        /*
+         * operators with base type as one argument
+         */
+        inline TpsaWithOp& operator += (const typename T::base_type& o ){ this->set(   1e0,    o); return *this; }
+        inline TpsaWithOp& operator -= (const typename T::base_type& o ){ this->set(   1e0,   -o); return *this; }
+        inline TpsaWithOp& operator *= (const typename T::base_type& o ){ this->set(     o,  0e0); return *this; }
+        inline TpsaWithOp& operator /= (const typename T::base_type& o ){ this->set( 1e0/o,  0e0); return *this; }
 
 #ifndef GTSPA_ONLY_OPTIMISED_OPS
-	/**
-	 * @brief negation
-	 * @todo do I need to make a copy ....?
-	 */
-	inline TpsaWithOp  operator -  (void) const { auto r = this->newFromThis(); r.m_impl.scl(this->m_impl, -1); return r; }
+        /**
+         * @brief negation
+         * @todo do I need to make a copy ....?
+         */
+        inline TpsaWithOp  operator -  (void) const { auto r = this->newFromThis(); r.m_impl.scl(this->m_impl, -1); return r; }
 
-	inline TpsaWithOp  operator +  (const typename T::base_type o) const { auto r = this->newFromThis(); r.set(0, o); r += *this;     return r; }
-	inline TpsaWithOp  operator -  (const typename T::base_type o) const { auto r = this->newFromThis(); r.set(0, o); return *this - r;         }
-	inline TpsaWithOp  operator *  (const typename T::base_type o) const { auto r = this->newFromThis(); r.set(0, o); r *= *this;     return r; }
-	inline TpsaWithOp  operator /  (const typename T::base_type o) const { auto r = this->newFromThis(); r.set(0, o); return *this / r;         }
+        inline TpsaWithOp  operator +  (const typename T::base_type o) const { auto r = this->newFromThis(); r.set(0, o); r += *this;     return r; }
+        inline TpsaWithOp  operator -  (const typename T::base_type o) const { auto r = this->newFromThis(); r.set(0, o); return *this - r;         }
+        inline TpsaWithOp  operator *  (const typename T::base_type o) const { auto r = this->newFromThis(); r.set(0, o); r *= *this;     return r; }
+        inline TpsaWithOp  operator /  (const typename T::base_type o) const { auto r = this->newFromThis(); r.set(0, o); return *this / r;         }
 #endif // GTSPA_ONLY_OPTIMISED_OPS
 
-	/*
-	 * Some minimal support for input output
-	 */
-	// forward declaration ... needs to be implemented in the derived class
-	void show(std::ostream& strm, int level) const
-	{
+        /*
+         * Some minimal support for input output
+         */
+        // forward declaration ... needs to be implemented in the derived class
+        void show(std::ostream& strm, int level) const
+        {
 
-	    strm << "gtpsa  cst:\n\t" << this->cst();
-	    if(this->order()){
-		// at least first order ...
-		const auto& info = this->getDescription()->getInfo();
-		const int nn = info.getNumberOfVariables() + info.getNumberOfParameters();
-		std::vector<typename T::base_type> v(nn);
-		this->getv(1, &v);
+            strm << "gtpsa  cst:\n\t" << this->cst();
+            if(this->order()){
+                // at least first order ...
+                const auto& info = this->getDescription()->getInfo();
+                const int nn = info.getNumberOfVariables() + info.getNumberOfParameters();
+                std::vector<typename T::base_type> v(nn);
+                this->getv(1, &v);
 
-		strm  << "\ngtpsa linear :\n"
-		      << std::scientific << std::setw(20);
-		for(auto& e: v) strm <<  std::scientific << std::setw(20) << e << " ";
-	    }
-	    strm << "\n";
-	}
+                strm  << "\ngtpsa linear :\n"
+                      << std::scientific << std::setw(20);
+                for(auto& e: v) strm <<  std::scientific << std::setw(20) << e << " ";
+            }
+            strm << "\n";
+        }
 
-	/**
-	 *
-	 * @todo: how to find the total number of coefficients?
-	 */
-	inline auto getCoefficients(void) const {
-	    const auto n_max = this->getDescription()->getInfo().getTotalNumber();
-	    std::vector< std::tuple<std::vector<ord_t>, base_type, idx_t> > coefficients;
-	    int i = -1;
-	    while(true){
-		std::vector<ord_t> t_orders(n_max);
-		const auto r = this->cycle(i, &t_orders);
-		i = r.first;
-		if(i == -1){
-		    break;
-		}
-		coefficients.push_back(std::tie(t_orders, r.second, i));
-	    };
-	    return coefficients;
-	}
+        /**
+         *
+         * @todo: how to find the total number of coefficients?
+         */
+        std::vector<coeff_t> getCoefficients(void) const {
+            const auto n_max = this->getDescription()->getInfo().getTotalNumber();
+            std::vector<coeff_t> coefficients;
+            int i = -1;
+            while(true){
+                std::vector<ord_t> t_orders(n_max);
+                const auto r = this->cycle(i, &t_orders);
+                i = r.first;
+                if(i == -1){
+                    break;
+                }
+                coefficients.push_back(std::tie(t_orders, r.second, i));
+            };
+            return coefficients;
+        }
 
-	/**
-	 * @brief support python representation of this object
-	 */
-	inline std::string repr(void) const {
-	    std::stringstream strm;
-	    this->show(strm, 10);
-	    return strm.str();
-	}
-	/**
-	 * @brief support python __str__ of this object
-	 */
-	std::string pstr(void) const {
-	    std::stringstream strm;
-	    this->show(strm, 0);
-	    return strm.str();
-	}
+        void setCoefficients(const std::vector<coeff_t> coeffs) {
+            for(const auto& c : coeffs) {
+                const auto& orders = std::get<0>(c);
+                const auto val = std::get<1>(c);
+                this->set(orders, 0e0, val);
+            }
+        }
+
+        /**
+         * @brief support python representation of this object
+         */
+        inline std::string repr(void) const {
+            std::stringstream strm;
+            this->show(strm, 10);
+            return strm.str();
+        }
+        /**
+         * @brief support python __str__ of this object
+         */
+        std::string pstr(void) const {
+            std::stringstream strm;
+            this->show(strm, 0);
+            return strm.str();
+        }
     /*
     void convolve() {
         mad::compose(ma, mb, mc);
@@ -167,8 +175,8 @@ namespace gtpsa {
     template<class T, typename, typename, typename>
     inline std::ostream& operator<<(std::ostream& strm, const TpsaWithOp<T>& a)
     {
-	a.show(strm, 0);
-	return strm;
+        a.show(strm, 0);
+        return strm;
     }
 
 

--- a/tests/c++/test_arithmetic.cc
+++ b/tests/c++/test_arithmetic.cc
@@ -692,7 +692,28 @@ BOOST_AUTO_TEST_CASE(test80_compare){
     t2.print("t3", 1e-12);
     fflush(stdout);
     std::cout << std::endl;
-    t2.getCoefficients();
+    const auto& coeffs = t2.getCoefficients();
+
+    gtpsa::tpsa t4(a_desc, gtpsa::mad::default_);
+    t4.setCoefficients(coeffs);
+
+    std::cout << t2 << t2 << std::endl;
+    std::cout << t4 << t4 << std::endl;
+    t4.setName("t4");
+    t4.print();
+
+    auto tmp = t4 - t2;
+    tmp.setName("t4 - t2");
+    // std::cout << tmp << std::endl;
+    // tmp.print();
+
+    {
+        const auto& coeffs = tmp.getCoefficients();
+        for(const auto& c: coeffs){
+            BOOST_CHECK_SMALL(std::get<1>(c), 1e-12);
+        }
+    }
+
 }
 
 BOOST_AUTO_TEST_CASE(test90_atan2){

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -3,5 +3,13 @@ target_link_libraries(test_desc_double_allocate
         gtpsa
         lapack
         blas
-        )
+)
 add_test(desc_double_allocate test_desc_double_allocate)
+
+add_executable(test_desc_many_pars test_desc_many_pars.c)
+target_link_libraries(test_desc_many_pars
+        gtpsa
+        lapack
+        blas
+)
+add_test(desc_many_pars test_desc_many_pars)

--- a/tests/c/test_desc_many_pars.c
+++ b/tests/c/test_desc_many_pars.c
@@ -1,0 +1,14 @@
+#include <mad_desc.h>
+#include <assert.h>
+#include <stdio.h>
+
+int main(void)
+{
+    const int nv=6, np=144;
+    const ord_t mo=7, po=1;
+
+    const desc_t* d = mad_desc_newvp (nv, mo, np, po);
+    assert(d);
+    mad_desc_info(d, NULL);
+
+}


### PR DESCRIPTION
A desc object with a large number of parameters (e.g. 144 of second order) would 
exceed some limits of tpsa. Such allocation will now fail as  mad-ng's gtpsa let it fail
